### PR TITLE
Embed competition intro video and redesign site with polished dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,182 +6,349 @@
     <title>0xf1sh - Social Engineering Competition Team</title>
     <meta name="description" content="0xf1sh CTF Team - Social Engineering Competition Participants">
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <script>
         tailwind.config = {
             darkMode: 'class',
             theme: {
                 extend: {
+                    fontFamily: {
+                        mono: ['JetBrains Mono', 'monospace'],
+                        sans: ['Inter', 'system-ui', 'sans-serif']
+                    },
                     colors: {
-                        accent: '#3b82f6',
-                        background: '#ffffff',
-                        border: '#e5e7eb'
+                        accent: '#60a5fa',
+                        'accent-dim': '#3b82f6',
+                        surface: {
+                            DEFAULT: '#0d1117',
+                            light: '#161b22',
+                            lighter: '#21262d',
+                        }
                     }
                 }
             }
         }
     </script>
     <style>
-        .dark {
-            --tw-bg-opacity: 1;
-            background-color: rgb(17 24 39 / var(--tw-bg-opacity));
-            color: rgb(243 244 246 / var(--tw-bg-opacity));
+        body {
+            background-color: #0d1117;
+            color: #e6edf3;
+            font-family: 'Inter', system-ui, sans-serif;
         }
-        .dark .border-border {
-            border-color: rgb(55 65 81 / var(--tw-bg-opacity));
+
+        .gradient-text {
+            background: linear-gradient(135deg, #60a5fa 0%, #a78bfa 50%, #60a5fa 100%);
+            background-size: 200% auto;
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            animation: shimmer 3s linear infinite;
         }
-        .dark .text-accent {
-            color: rgb(59 130 246 / var(--tw-bg-opacity));
+
+        @keyframes shimmer {
+            to { background-position: 200% center; }
         }
-        .dark .hover\:text-accent:hover {
-            color: rgb(59 130 246 / var(--tw-bg-opacity));
+
+        .glow-border {
+            border: 1px solid rgba(96, 165, 250, 0.15);
+            box-shadow: 0 0 20px rgba(96, 165, 250, 0.05);
+            transition: border-color 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .glow-border:hover {
+            border-color: rgba(96, 165, 250, 0.35);
+            box-shadow: 0 0 30px rgba(96, 165, 250, 0.1);
+        }
+
+        .card {
+            background: #161b22;
+            border: 1px solid #30363d;
+            border-radius: 0.75rem;
+            transition: all 0.3s ease;
+        }
+
+        .card:hover {
+            border-color: #60a5fa33;
+            transform: translateY(-2px);
+            box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+        }
+
+        .nav-link {
+            position: relative;
+            color: #8b949e;
+            transition: color 0.2s ease;
+        }
+
+        .nav-link:hover {
+            color: #e6edf3;
+        }
+
+        .nav-link::after {
+            content: '';
+            position: absolute;
+            bottom: -4px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: #60a5fa;
+            transition: width 0.3s ease;
+        }
+
+        .nav-link:hover::after {
+            width: 100%;
+        }
+
+        .video-container {
+            position: relative;
+            overflow: hidden;
+            border-radius: 0.75rem;
+            border: 1px solid #30363d;
+            background: #0d1117;
+        }
+
+        .video-container::before {
+            content: '';
+            position: absolute;
+            inset: -1px;
+            border-radius: 0.75rem;
+            padding: 1px;
+            background: linear-gradient(135deg, #60a5fa33, transparent 50%, #a78bfa33);
+            -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+            mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+            -webkit-mask-composite: xor;
+            mask-composite: exclude;
+            pointer-events: none;
+            z-index: 1;
+        }
+
+        .section-title {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+        }
+
+        .section-title::before {
+            content: '// ';
+            color: #484f58;
+        }
+
+        .tag {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            background: rgba(96, 165, 250, 0.1);
+            border: 1px solid rgba(96, 165, 250, 0.2);
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-family: 'JetBrains Mono', monospace;
+            color: #60a5fa;
+        }
+
+        .divider {
+            height: 1px;
+            background: linear-gradient(90deg, transparent, #30363d 20%, #30363d 80%, transparent);
+        }
+
+        .footer-link {
+            color: #8b949e;
+            transition: color 0.2s ease;
+        }
+
+        .footer-link:hover {
+            color: #60a5fa;
+        }
+
+        .pulse-dot {
+            width: 8px;
+            height: 8px;
+            background: #3fb950;
+            border-radius: 50%;
+            animation: pulse 2s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
+
+        .member-avatar {
+            width: 48px;
+            height: 48px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1.1rem;
+            color: #0d1117;
+            flex-shrink: 0;
         }
     </style>
 </head>
-<body class="bg-background text-gray-900 dark:text-gray-100 min-h-screen">
-    <header class="border-b border-border">
-        <div class="mx-auto max-w-4xl px-4 py-6">
+<body class="min-h-screen">
+    <!-- Header -->
+    <header class="sticky top-0 z-50 backdrop-blur-md bg-[#0d1117]/80 border-b border-[#21262d]">
+        <div class="mx-auto max-w-5xl px-6 py-4">
             <div class="flex items-center justify-between">
-                <a href="https://0xf1.sh" class="text-2xl font-bold text-accent hover:text-blue-600 transition-colors">
-                    0xf1sh
+                <a href="https://0xf1.sh" class="flex items-center gap-3 group">
+                    <span class="font-mono text-xl font-bold text-[#e6edf3] group-hover:text-accent transition-colors">
+                        0xf1sh
+                    </span>
+                    <span class="hidden sm:inline tag">SEC Team</span>
                 </a>
-                <nav class="flex items-center space-x-6">
-                    <a href="https://0xf1.sh/posts" class="hover:text-accent transition-colors">Writeups</a>
-                    <a href="https://0xf1.sh/members" class="hover:text-accent transition-colors">Members</a>
-                    <button id="theme-toggle" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="sun-icon">
-                            <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z"/>
-                        </svg>
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="moon-icon hidden">
-                            <path d="M14.828 14.828a4 4 0 1 0 -5.656 -5.656a4 4 0 0 0 5.656 5.656z"/>
-                            <path d="M6.343 17.657l-1.414 1.414"/>
-                            <path d="M6.343 6.343l-1.414 -1.414"/>
-                            <path d="M17.657 6.343l1.414 -1.414"/>
-                            <path d="M17.657 17.657l1.414 1.414"/>
-                            <path d="M4 12h-2"/>
-                            <path d="M12 4v-2"/>
-                            <path d="M20 12h2"/>
-                            <path d="M12 20v2"/>
-                        </svg>
-                    </button>
+                <nav class="flex items-center gap-6">
+                    <a href="https://0xf1.sh/posts" class="nav-link text-sm font-medium">Writeups</a>
+                    <a href="https://0xf1.sh/members" class="nav-link text-sm font-medium">Members</a>
+                    <a href="https://github.com/0xf1shCTF" class="nav-link text-sm font-medium hidden sm:block">GitHub</a>
                 </nav>
             </div>
         </div>
     </header>
 
-    <main class="mx-auto max-w-4xl px-4 py-12">
-        <section class="mb-12">
-            <h1 class="text-4xl font-bold mb-4">0xf1sh</h1>
-            <p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
-                Social Engineering Competition Team Page
+    <main class="mx-auto max-w-5xl px-6">
+        <!-- Hero Section -->
+        <section class="pt-20 pb-16 text-center">
+            <div class="inline-flex items-center gap-2 mb-6">
+                <div class="pulse-dot"></div>
+                <span class="text-sm font-mono text-[#8b949e]">Social Engineering Competition 2026</span>
+            </div>
+            <h1 class="text-5xl sm:text-6xl font-bold mb-6">
+                <span class="gradient-text font-mono">0xf1sh</span>
+            </h1>
+            <p class="text-lg text-[#8b949e] max-w-2xl mx-auto leading-relaxed">
+                Competitive CTF team specializing in social engineering, OSINT, and creative problem-solving.
             </p>
+            <div class="flex justify-center gap-3 mt-8">
+                <span class="tag">social-engineering</span>
+                <span class="tag">OSINT</span>
+                <span class="tag">CTF</span>
+            </div>
         </section>
 
-        <section class="mb-12">
-            <h2 class="text-2xl font-semibold mb-6 border-b border-border pb-2">Team Information</h2>
+        <div class="divider"></div>
 
-            <div class="space-y-6">
-                <div>
-                    <h3 class="text-lg font-medium mb-2">Team Name</h3>
-                    <p class="text-accent font-semibold">0xf1sh</p>
-                </div>
+        <!-- Video Section -->
+        <section class="py-16">
+            <h2 class="section-title text-2xl mb-3 text-[#e6edf3]">Competition Introduction</h2>
+            <p class="text-[#8b949e] mb-8 max-w-xl">Watch our team's introduction video for the Social Engineering Competition.</p>
 
-                <div>
-                    <h3 class="text-lg font-medium mb-2">Institution</h3>
-                    <p>0xf1sh CTF Team</p>
-                </div>
-
-                <div>
-                    <h3 class="text-lg font-medium mb-2">Faculty Advisor</h3>
-                    <p>Stephen (Logix)</p>
+            <div class="video-container">
+                <div class="aspect-video">
+                    <iframe
+                        class="w-full h-full"
+                        src="https://www.youtube.com/embed/vwrnPFJ7AX0?si=IKYGljfTWkDUZC5x"
+                        title="0xf1sh - Social Engineering Competition Introduction"
+                        frameborder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        referrerpolicy="strict-origin-when-cross-origin"
+                        allowfullscreen>
+                    </iframe>
                 </div>
             </div>
         </section>
 
-        <section class="mb-12">
-            <h2 class="text-2xl font-semibold mb-6 border-b border-border pb-2">Team Members</h2>
+        <div class="divider"></div>
 
-            <div class="grid gap-6 md:grid-cols-1">
-                <div class="bg-gray-50 dark:bg-gray-800 p-6 rounded-lg">
-                    <h3 class="text-xl font-semibold mb-3">Member 1</h3>
-                    <p class="text-gray-600 dark:text-gray-400">
-                        Placeholder bio for Member 1. This is where you can describe the member's background,
-                        interests, skills, and their role in the team. Include information about their experience
-                        in cybersecurity, CTF competitions, or relevant technical expertise.
-                    </p>
+        <!-- Team Info Section -->
+        <section class="py-16">
+            <h2 class="section-title text-2xl mb-8 text-[#e6edf3]">Team Details</h2>
+
+            <div class="grid gap-4 sm:grid-cols-3">
+                <div class="card p-6">
+                    <p class="text-xs font-mono text-[#484f58] uppercase tracking-wider mb-2">Team Name</p>
+                    <p class="text-lg font-semibold text-accent font-mono">0xf1sh</p>
                 </div>
-
-                <div class="bg-gray-50 dark:bg-gray-800 p-6 rounded-lg">
-                    <h3 class="text-xl font-semibold mb-3">Member 2</h3>
-                    <p class="text-gray-600 dark:text-gray-400">
-                        Placeholder bio for Member 2. This is where you can describe the member's background,
-                        interests, skills, and their role in the team. Include information about their experience
-                        in cybersecurity, CTF competitions, or relevant technical expertise.
-                    </p>
+                <div class="card p-6">
+                    <p class="text-xs font-mono text-[#484f58] uppercase tracking-wider mb-2">Organization</p>
+                    <p class="text-lg font-semibold text-[#e6edf3]">0xf1sh CTF Team</p>
                 </div>
-
-                <div class="bg-gray-50 dark:bg-gray-800 p-6 rounded-lg">
-                    <h3 class="text-xl font-semibold mb-3">Member 3</h3>
-                    <p class="text-gray-600 dark:text-gray-400">
-                        Placeholder bio for Member 3. This is where you can describe the member's background,
-                        interests, skills, and their role in the team. Include information about their experience
-                        in cybersecurity, CTF competitions, or relevant technical expertise.
-                    </p>
+                <div class="card p-6">
+                    <p class="text-xs font-mono text-[#484f58] uppercase tracking-wider mb-2">Faculty Advisor</p>
+                    <p class="text-lg font-semibold text-[#e6edf3]">Stephen <span class="text-[#8b949e] font-normal">(Logix)</span></p>
                 </div>
             </div>
         </section>
 
-        <section class="mb-12">
-            <h2 class="text-2xl font-semibold mb-6 border-b border-border pb-2">Competition Introduction Video</h2>
+        <div class="divider"></div>
 
-            <div class="bg-gray-50 dark:bg-gray-800 p-6 rounded-lg">
-                <p class="text-gray-600 dark:text-gray-400 mb-4">
-                    Our introduction video for the Social Engineering Competition.
-                </p>
-                <div class="aspect-video bg-gray-200 dark:bg-gray-700 rounded-lg flex items-center justify-center">
-                    <div class="text-center">
-                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="mx-auto mb-2 text-gray-400">
-                            <path d="M15 10l4.553-2.276A1 1 0 0 1 21 8.618v6.764a1 1 0 0 1-1.447.894L15 14M5 18h8a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2z"/>
-                        </svg>
-                        <p class="text-gray-500 dark:text-gray-400">Video placeholder - Replace with actual embed code</p>
-                        <p class="text-sm text-gray-400 mt-2">Example: &lt;iframe width="560" height="315" src="https://www.youtube.com/embed/VIDEO_ID" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;</p>
+        <!-- Team Members Section -->
+        <section class="py-16">
+            <h2 class="section-title text-2xl mb-8 text-[#e6edf3]">Team Members</h2>
+
+            <div class="grid gap-4">
+                <div class="card p-6 flex items-start gap-4">
+                    <div class="member-avatar">01</div>
+                    <div class="min-w-0">
+                        <h3 class="text-lg font-semibold text-[#e6edf3] mb-1">Member 1</h3>
+                        <p class="text-sm text-[#8b949e] leading-relaxed">
+                            Team member background, interests, skills, and role. Experience in cybersecurity,
+                            CTF competitions, and technical expertise.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="card p-6 flex items-start gap-4">
+                    <div class="member-avatar">02</div>
+                    <div class="min-w-0">
+                        <h3 class="text-lg font-semibold text-[#e6edf3] mb-1">Member 2</h3>
+                        <p class="text-sm text-[#8b949e] leading-relaxed">
+                            Team member background, interests, skills, and role. Experience in cybersecurity,
+                            CTF competitions, and technical expertise.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="card p-6 flex items-start gap-4">
+                    <div class="member-avatar">03</div>
+                    <div class="min-w-0">
+                        <h3 class="text-lg font-semibold text-[#e6edf3] mb-1">Member 3</h3>
+                        <p class="text-sm text-[#8b949e] leading-relaxed">
+                            Team member background, interests, skills, and role. Experience in cybersecurity,
+                            CTF competitions, and technical expertise.
+                        </p>
                     </div>
                 </div>
             </div>
         </section>
     </main>
 
-    <footer class="border-t border-border mt-16">
-        <div class="mx-auto max-w-4xl px-4 py-8">
-            <div class="flex flex-col md:flex-row justify-between items-center">
-                <div class="mb-4 md:mb-0">
-                    <p class="text-gray-600 dark:text-gray-400">
-                        © 2026 0xf1sh CTF Team. All rights reserved.
-                    </p>
+    <!-- Footer -->
+    <footer class="border-t border-[#21262d] mt-8">
+        <div class="mx-auto max-w-5xl px-6 py-10">
+            <div class="flex flex-col sm:flex-row justify-between items-center gap-6">
+                <div class="flex items-center gap-4">
+                    <span class="font-mono text-sm font-semibold text-[#e6edf3]">0xf1sh</span>
+                    <span class="text-[#30363d]">|</span>
+                    <span class="text-sm text-[#484f58]">&copy; 2026</span>
                 </div>
-                <div class="flex space-x-4">
-                    <a href="https://github.com/0xf1shCTF" class="text-gray-600 dark:text-gray-400 hover:text-accent transition-colors">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5"/>
+                <div class="flex items-center gap-6">
+                    <a href="https://github.com/0xf1shCTF" class="footer-link flex items-center gap-2 text-sm" aria-label="GitHub">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                         </svg>
+                        <span class="hidden sm:inline">GitHub</span>
                     </a>
-                    <a href="https://ctftime.org/team/299716" class="text-gray-600 dark:text-gray-400 hover:text-accent transition-colors">
-                        CTFtime
+                    <a href="https://ctftime.org/team/299716" class="footer-link flex items-center gap-2 text-sm">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/>
+                            <line x1="4" y1="22" x2="4" y2="15"/>
+                        </svg>
+                        <span class="hidden sm:inline">CTFtime</span>
+                    </a>
+                    <a href="https://0xf1.sh" class="footer-link flex items-center gap-2 text-sm">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="2" y1="12" x2="22" y2="12"/>
+                            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+                        </svg>
+                        <span class="hidden sm:inline">Website</span>
                     </a>
                 </div>
             </div>
         </div>
     </footer>
-
-    <script>
-        const themeToggle = document.getElementById('theme-toggle');
-        const sunIcon = document.querySelector('.sun-icon');
-        const moonIcon = document.querySelector('.moon-icon');
-
-        themeToggle.addEventListener('click', () => {
-            document.documentElement.classList.toggle('dark');
-            sunIcon.classList.toggle('hidden');
-            moonIcon.classList.toggle('hidden');
-        });
-    </script>
 </body>
 </html>


### PR DESCRIPTION
- Embed YouTube video (vwrnPFJ7AX0) replacing the placeholder
- Redesign with dark GitHub-inspired aesthetic matching 0xf1.sh style
- Add JetBrains Mono + Inter fonts, gradient effects, and hover animations
- Sticky header with backdrop blur, gradient bordered video container
- Card-based layout with subtle glow effects and numbered member avatars
- Responsive grid for team details, animated shimmer on hero title

https://claude.ai/code/session_01XabbLAe1vqmnvGZq9LetYX